### PR TITLE
Switch max-age over to u64

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use time::{Tm, Duration};
+use time::Tm;
 
 use ::{Cookie, SameSite};
 
@@ -27,7 +27,7 @@ use ::{Cookie, SameSite};
 ///     .path("/")
 ///     .secure(true)
 ///     .http_only(true)
-///     .max_age(Duration::days(1))
+///     .max_age(60 * 60 * 24)
 ///     .finish();
 /// # }
 /// ```
@@ -87,22 +87,16 @@ impl CookieBuilder {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate cookie;
-    /// extern crate time;
-    /// use time::Duration;
-    ///
     /// use cookie::Cookie;
     ///
-    /// # fn main() {
     /// let c = Cookie::build("foo", "bar")
-    ///     .max_age(Duration::minutes(30))
+    ///     .max_age(60 * 30)
     ///     .finish();
     ///
-    /// assert_eq!(c.max_age(), Some(Duration::seconds(30 * 60)));
-    /// # }
+    /// assert_eq!(c.max_age(), Some(60 * 30));
     /// ```
     #[inline]
-    pub fn max_age(mut self, value: Duration) -> CookieBuilder {
+    pub fn max_age(mut self, value: u64) -> CookieBuilder {
         self.cookie.set_max_age(value);
         self
     }
@@ -217,7 +211,8 @@ impl CookieBuilder {
     ///     .permanent()
     ///     .finish();
     ///
-    /// assert_eq!(c.max_age(), Some(Duration::days(365 * 20)));
+    /// let twenty_years = 60 * 60 * 24 * 365 * 20;
+    /// assert_eq!(c.max_age(), Some(twenty_years));
     /// # assert!(c.expires().is_some());
     /// # }
     /// ```

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -201,7 +201,7 @@ impl CookieJar {
     /// let delta: Vec<_> = jar.delta().collect();
     /// assert_eq!(delta.len(), 1);
     /// assert_eq!(delta[0].name(), "name");
-    /// assert_eq!(delta[0].max_age(), Some(Duration::seconds(0)));
+    /// assert_eq!(delta[0].max_age(), Some(0));
     /// # }
     /// ```
     ///
@@ -220,7 +220,7 @@ impl CookieJar {
     pub fn remove(&mut self, cookie: Cookie<'static>) {
         fn make_removal_cookie(mut cookie: Cookie<'static>) -> DeltaCookie {
             cookie.set_value("");
-            cookie.set_max_age(Duration::seconds(0));
+            cookie.set_max_age(0);
             cookie.set_expires(time::now() - Duration::days(365));
             DeltaCookie::removed(cookie)
         }
@@ -491,7 +491,6 @@ mod test {
     #[cfg(feature = "secure")]
     fn delta() {
         use std::collections::HashMap;
-        use time::Duration;
 
         let mut c = CookieJar::new();
 
@@ -515,7 +514,7 @@ mod test {
         assert!(names.get("test2").unwrap().is_none());
         assert!(names.get("test3").unwrap().is_none());
         assert!(names.get("test4").unwrap().is_none());
-        assert_eq!(names.get("original").unwrap(), &Some(Duration::seconds(0)));
+        assert_eq!(names.get("original").unwrap(), &Some(0));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,8 @@ pub struct Cookie<'c> {
     value: CookieStr,
     /// The cookie's experiation, if any.
     expires: Option<Tm>,
-    /// The cookie's maximum age, if any.
-    max_age: Option<Duration>,
+    /// The cookie's maximum age in seconds, if any.
+    max_age: Option<u64>,
     /// The cookie's domain, if any.
     domain: Option<CookieStr>,
     /// The cookie's path domain, if any.
@@ -435,10 +435,10 @@ impl<'c> Cookie<'c> {
     /// assert_eq!(c.max_age(), None);
     ///
     /// let c = Cookie::parse("name=value; Max-Age=3600").unwrap();
-    /// assert_eq!(c.max_age().map(|age| age.num_hours()), Some(1));
+    /// assert_eq!(c.max_age(), Some(3600));
     /// ```
     #[inline]
-    pub fn max_age(&self) -> Option<Duration> {
+    pub fn max_age(&self) -> Option<u64> {
         self.max_age
     }
 
@@ -610,12 +610,13 @@ impl<'c> Cookie<'c> {
     /// let mut c = Cookie::new("name", "value");
     /// assert_eq!(c.max_age(), None);
     ///
-    /// c.set_max_age(Duration::hours(10));
-    /// assert_eq!(c.max_age(), Some(Duration::hours(10)));
+    /// let ten_hours = 60 * 60 * 10;
+    /// c.set_max_age(ten_hours);
+    /// assert_eq!(c.max_age(), Some(ten_hours));
     /// # }
     /// ```
     #[inline]
-    pub fn set_max_age(&mut self, value: Duration) {
+    pub fn set_max_age(&mut self, value: u64) {
         self.max_age = Some(value);
     }
 
@@ -697,14 +698,16 @@ impl<'c> Cookie<'c> {
     /// assert!(c.max_age().is_none());
     ///
     /// c.make_permanent();
+    ///
+    /// let twenty_years = 60 * 60 * 24 * 365 * 20;
     /// assert!(c.expires().is_some());
-    /// assert_eq!(c.max_age(), Some(Duration::days(365 * 20)));
+    /// assert_eq!(c.max_age(), Some(60 * 60 * 24 * 365 * 20));
     /// # }
     /// ```
     pub fn make_permanent(&mut self) {
-        let twenty_years = Duration::days(365 * 20);
+        let twenty_years = 60 * 60 * 24 * 365 * 20;
         self.set_max_age(twenty_years);
-        self.set_expires(time::now() + twenty_years);
+        self.set_expires(time::now() + Duration::seconds(twenty_years as i64));
     }
 
     fn fmt_parameters(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -729,7 +732,7 @@ impl<'c> Cookie<'c> {
         }
 
         if let Some(max_age) = self.max_age() {
-            write!(f, "; Max-Age={}", max_age.num_seconds())?;
+            write!(f, "; Max-Age={}", max_age)?;
         }
 
         if let Some(time) = self.expires() {
@@ -961,7 +964,7 @@ impl<'a, 'b> PartialEq<Cookie<'b>> for Cookie<'a> {
 #[cfg(test)]
 mod tests {
     use ::{Cookie, SameSite};
-    use ::time::{strptime, Duration};
+    use ::time::strptime;
 
     #[test]
     fn format() {
@@ -973,7 +976,7 @@ mod tests {
         assert_eq!(&cookie.to_string(), "foo=bar; HttpOnly");
 
         let cookie = Cookie::build("foo", "bar")
-            .max_age(Duration::seconds(10)).finish();
+            .max_age(10).finish();
         assert_eq!(&cookie.to_string(), "foo=bar; Max-Age=10");
 
         let cookie = Cookie::build("foo", "bar")


### PR DESCRIPTION
This is a breaking change. In #85, it was suggested that we remove the public dependency on `time::Duration` since that crate is deprecated. According to the [Cookie spec](https://tools.ietf.org/html/rfc6265#section-5.2.2), `Max-Age` is in seconds that is either zero or always positive. Negative numbers are always parsed to the earliest representable date and time, which would be 0.