### PR TITLE
Add 'CookieJar::parse_from_header' to parse a CookieJar from a HTTP Cookie header

### DIFF
--- a/src/jar.rs
+++ b/src/jar.rs
@@ -6,7 +6,7 @@ use time::{self, Duration};
 #[cfg(feature = "secure")]
 use secure::{PrivateJar, SignedJar, Key};
 use delta::DeltaCookie;
-use Cookie;
+use {Cookie, ParseError};
 
 /// A collection of cookies that tracks its modifications.
 ///
@@ -98,6 +98,20 @@ impl CookieJar {
     /// ```
     pub fn new() -> CookieJar {
         CookieJar::default()
+    }
+
+    /// Parses a cookie jar from a semicolon delimited list of `name=value` pairs commonly
+    /// found in the HTTP Cookie header.
+    pub fn parse_from_header(s: &str) -> Result<CookieJar, ParseError> {
+        let mut jar = CookieJar::new();
+
+        s.split(';').try_for_each(|s| -> Result<_, ParseError> {
+            jar.add(Cookie::parse(s.trim().to_owned())?);
+
+            Ok(())
+        })?;
+
+        Ok(jar)
     }
 
     /// Returns a reference to the `Cookie` inside this jar with the name


### PR DESCRIPTION
```rust
let jar = CookieJar::parse_from_header("key=value; other=other value")?;
```

---

Been using this method in my projects for a while now and decided to send a PR to see if there is interest in adding it to `cookie`. I'll add tests and improve documentation if its decided that this should be added.

---

In the same vein I also have a `CookieJar::to_header_string()` method I'd like to contribute as well. It takes a `CookieJar` and writes it to a semicolon-delimited key=value string like in the HTTP cookie header.