### PR TITLE
bump to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cookie"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Sergio Benitez <sb@sergio.bz>"]
-version = "0.11.0"
+version = "0.12.0"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cookie-rs"
 documentation = "https://docs.rs/cookie"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! features = ["secure", "percent-encode"]
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/cookie/0.11")]
+#![doc(html_root_url = "https://docs.rs/cookie/0.12")]
 #![deny(missing_docs)]
 
 #[cfg(feature = "percent-encode")] extern crate url;


### PR DESCRIPTION
closes #115, closes #117.

cc: @alexcrichton @SergioBenitez 