### PR TITLE
Use the radix64 crate to perform base64 encoding/decoding.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ and private (encrypted + signed) jars.
 """
 
 [features]
-secure = ["ring", "base64"]
+secure = ["ring", "radix64"]
 percent-encode = ["url"]
 
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
 ring = { version = "0.14.0", optional = true }
-base64 = { version = "0.10.0", optional = true }
+radix64 = { version = "0.6", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/secure/mod.rs
+++ b/src/secure/mod.rs
@@ -1,5 +1,5 @@
 extern crate ring;
-extern crate base64;
+extern crate radix64;
 
 #[macro_use]
 mod macros;
@@ -10,3 +10,5 @@ mod key;
 pub use self::private::*;
 pub use self::signed::*;
 pub use self::key::*;
+
+use self::radix64::STD as base64;

--- a/src/secure/private.rs
+++ b/src/secure/private.rs
@@ -41,7 +41,7 @@ impl<'a> PrivateJar<'a> {
     /// verifies and decrypts the sealed value and returns it. If there's a
     /// problem, returns an `Err` with a string describing the issue.
     fn unseal(&self, name: &str, value: &str) -> Result<String, &'static str> {
-        let mut data = base64::decode(value).map_err(|_| "bad base64 value")?;
+        let mut data = base64.decode(value).map_err(|_| "bad base64 value")?;
         if data.len() <= NONCE_LEN {
             return Err("length of decoded data is <= NONCE_LEN");
         }
@@ -169,7 +169,7 @@ impl<'a> PrivateJar<'a> {
         };
 
         // Base64 encode the nonce and encrypted value.
-        let sealed_value = base64::encode(&data[..(NONCE_LEN + output_len)]);
+        let sealed_value = base64.encode(&data[..(NONCE_LEN + output_len)]);
         cookie.set_value(sealed_value);
     }
 

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -42,7 +42,7 @@ impl<'a> SignedJar<'a> {
         }
 
         let (digest_str, value) = cookie_value.split_at(BASE64_DIGEST_LEN);
-        let sig = base64::decode(digest_str).map_err(|_| "bad base64 digest")?;
+        let sig = base64.decode(digest_str).map_err(|_| "bad base64 digest")?;
 
         verify(&self.key, value.as_bytes(), &sig)
             .map(|_| value.to_string())
@@ -129,7 +129,7 @@ impl<'a> SignedJar<'a> {
     /// Signs the cookie's value assuring integrity and authenticity.
     fn sign_cookie(&self, cookie: &mut Cookie) {
         let digest = sign(&self.key, cookie.value().as_bytes());
-        let mut new_value = base64::encode(digest.as_ref());
+        let mut new_value = base64.encode(digest.as_ref());
         new_value.push_str(cookie.value());
         cookie.set_value(new_value);
     }


### PR DESCRIPTION
Cards on the table: I'm the author of the radix64 crate.

This is a bit of self promotion and feel free to raise any concerns. The radix64 crate is faster at encoding and decoding both large and small inputs. The MSRV of radix64 is 1.31.0, which appears to match the already existing dependencies with the "secure" feature enabled.