### PR TITLE
Allow filling CookieJars from a Cookie header string

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -10,15 +10,15 @@ use Cookie;
 /// that when sent to the client removes the named cookie on the client's
 /// machine.
 #[derive(Clone, Debug)]
-pub struct DeltaCookie {
-    pub cookie: Cookie<'static>,
+pub struct DeltaCookie<'c> {
+    pub cookie: Cookie<'c>,
     pub removed: bool,
 }
 
-impl DeltaCookie {
+impl<'c> DeltaCookie<'c> {
     /// Create a new `DeltaCookie` that is being added to a jar.
     #[inline]
-    pub fn added(cookie: Cookie<'static>) -> DeltaCookie {
+    pub fn added(cookie: Cookie<'c>) -> DeltaCookie<'c> {
         DeltaCookie {
             cookie: cookie,
             removed: false,
@@ -28,7 +28,7 @@ impl DeltaCookie {
     /// Create a new `DeltaCookie` that is being removed from a jar. The
     /// `cookie` should be a "removal" cookie.
     #[inline]
-    pub fn removed(cookie: Cookie<'static>) -> DeltaCookie {
+    pub fn removed(cookie: Cookie<'c>) -> DeltaCookie<'c> {
         DeltaCookie {
             cookie: cookie,
             removed: true,
@@ -36,35 +36,35 @@ impl DeltaCookie {
     }
 }
 
-impl Deref for DeltaCookie {
-    type Target = Cookie<'static>;
+impl<'c> Deref for DeltaCookie<'c> {
+    type Target = Cookie<'c>;
 
-    fn deref(&self) -> &Cookie<'static> {
+    fn deref(&self) -> &Cookie<'c> {
         &self.cookie
     }
 }
 
-impl DerefMut for DeltaCookie {
-    fn deref_mut(&mut self) -> &mut Cookie<'static> {
+impl<'c> DerefMut for DeltaCookie<'c> {
+    fn deref_mut(&mut self) -> &mut Cookie<'c> {
         &mut self.cookie
     }
 }
 
-impl PartialEq for DeltaCookie {
+impl PartialEq for DeltaCookie<'_> {
     fn eq(&self, other: &DeltaCookie) -> bool {
         self.name() == other.name()
     }
 }
 
-impl Eq for DeltaCookie {}
+impl Eq for DeltaCookie<'_> {}
 
-impl Hash for DeltaCookie {
+impl Hash for DeltaCookie<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name().hash(state);
     }
 }
 
-impl Borrow<str> for DeltaCookie {
+impl Borrow<str> for DeltaCookie<'_> {
     fn borrow(&self) -> &str {
         self.name()
     }

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -452,7 +452,7 @@ impl<'c> CookieJar<'c> {
     /// assert!(jar.get("private").is_some());
     /// ```
     #[cfg(feature = "secure")]
-    pub fn private(&mut self, key: &Key) -> PrivateJar {
+    pub fn private<'a: 'b, 'b>(&'a mut self, key: &Key) -> PrivateJar<'b, 'c> {
         PrivateJar::new(self, key)
     }
 
@@ -490,7 +490,7 @@ impl<'c> CookieJar<'c> {
     /// assert!(jar.get("signed").is_some());
     /// ```
     #[cfg(feature = "secure")]
-    pub fn signed(&mut self, key: &Key) -> SignedJar {
+    pub fn signed<'a: 'b, 'b> (&'a mut self, key: &Key) -> SignedJar<'b, 'c> {
         SignedJar::new(self, key)
     }
 }


### PR DESCRIPTION
I needed this ability so that I could use this library with Hyper. Contemporary Hyper has no cookie parsing logic, so the ability to parse a `&str` into a CookieJar is very helpful for making stateful manipulations of cookies. Since this is only useful for a `&str` with a lifetime that isn't `'static`, I needed CookieJars to be able to hold Cookies with lifetimes that aren't `'static`, hence the sweeping addition of lifetimes to those structs. (thank you very much for the no-allocation parsing!)

The actual method is at `src/jar.rs:126`.

I did not bump the version, as I'm not quite sure how this interacts with semver requirements; I didn't have to modify anything in the test suite, but I can see how the addition of lifetime parameters might be a breaking change (e.g. if a SignedJar was a struct field).

Feel free to mention any tasks I can do to help merge this! I'm still fairly new to Rust so let me know if there's anything to improve.