### PR TITLE
Update parse to match RFC 6265 Grammar

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -112,7 +112,7 @@ fn parse_inner<'c>(s: &str, decode: bool) -> Result<Cookie<'c>, ParseError> {
     // Determine the name = val.
     let key_value = attributes.next().expect("first str::split().next() returns Some");
     let (name, value) = match key_value.find('=') {
-        Some(i) => (key_value[..i].trim(), key_value[(i + 1)..].trim()),
+        Some(i) => (key_value[..i].trim(), key_value[(i + 1)..].trim_matches(|c: char| c.is_whitespace() || c == '\"')),
         None => return Err(ParseError::MissingPair)
     };
 
@@ -321,7 +321,9 @@ mod tests {
         let mut expected = Cookie::build("foo", "bar").finish();
         assert_eq_parse!("foo=bar", expected);
         assert_eq_parse!("foo = bar", expected);
+        assert_eq_parse!("foo=\"bar\"", expected);
         assert_eq_parse!(" foo=bar ", expected);
+        assert_eq_parse!(" foo=\"bar\" ", expected);
         assert_eq_parse!(" foo=bar ;Domain=", expected);
         assert_eq_parse!(" foo=bar ;Domain= ", expected);
         assert_eq_parse!(" foo=bar ;Ignored", expected);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -106,8 +106,9 @@ fn name_val_decoded(
 }
 
 fn trim_quotes<'a>(s: &'a str) -> &'a str {
-    let first = s.chars().next();
-    let last = s.chars().last();
+    let mut chars = s.chars();
+    let first = chars.next();
+    let last = chars.last();
     match (first, last) {
         (Some('"'), Some('"')) => &s[1..s.len()-1],
         _ => s
@@ -116,7 +117,8 @@ fn trim_quotes<'a>(s: &'a str) -> &'a str {
 
 fn check_invalid(s: &str) -> Option<char> {
     for c in s.chars() {
-        if ['"', ',', ';', '\\'].contains(&c) {
+        if ['"', ',', ';', '\\'].contains(&c)
+           || c.is_whitespace() {
             return Some(c);
         }
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -341,7 +341,7 @@ mod tests {
         assert_eq_parse!("foo = bar", expected);
         assert_eq_parse!("foo=\"bar\"", expected);
         assert_eq_parse!(" foo=bar ", expected);
-        assert_eq_parse!(" foo=\"bar\" ", expected);
+        assert_eq_parse!(" foo=\"bar   \" ", expected);
         assert_eq_parse!(" foo=bar ;Domain=", expected);
         assert_eq_parse!(" foo=bar ;Domain= ", expected);
         assert_eq_parse!(" foo=bar ;Ignored", expected);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -106,10 +106,11 @@ fn name_val_decoded(
 }
 
 fn trim_quotes<'a>(s: &'a str) -> &'a str {
-    let mut chars = s.chars();
-    let first = chars.next();
-    let last = chars.last();
-    match (first, last) {
+    if s.len() < 2 {
+        return s;
+    }
+    
+    match (s.chars().next(), s.chars().last()) {
         (Some('"'), Some('"')) => &s[1..s.len()-1],
         _ => s
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -102,6 +102,15 @@ fn name_val_decoded(
     unreachable!("This function should never be called with 'percent-encode' disabled!")
 }
 
+fn trim_quotes<'a>(s: &'a str) -> &'a str {
+    let first = s.chars().next();
+    let last = s.chars().last();
+    match (first, last) {
+        (Some('"'), Some('"')) => &s[1..s.len()-1],
+        _ => s
+    }
+}
+
 // This function does the real parsing but _does not_ set the `cookie_string` in
 // the returned cookie object. This only exists so that the borrow to `s` is
 // returned at the end of the call, allowing the `cookie_string` field to be
@@ -112,7 +121,11 @@ fn parse_inner<'c>(s: &str, decode: bool) -> Result<Cookie<'c>, ParseError> {
     // Determine the name = val.
     let key_value = attributes.next().expect("first str::split().next() returns Some");
     let (name, value) = match key_value.find('=') {
-        Some(i) => (key_value[..i].trim(), key_value[(i + 1)..].trim_matches(|c: char| c.is_whitespace() || c == '\"')),
+        Some(i) => {
+            let (key, value) = (key_value[..i].trim(), key_value[(i + 1)..].trim());
+            let value = trim_quotes(value);
+            (key, value.trim())
+        },
         None => return Err(ParseError::MissingPair)
     };
 
@@ -317,6 +330,9 @@ mod tests {
 
         let expected = Cookie::build("foo", "bar=baz").finish();
         assert_eq_parse!("foo=bar=baz", expected);
+
+        let expected = Cookie::build("foo", "\"bar\"").finish();
+        assert_eq_parse!("foo=\"\"bar\"\"", expected);
 
         let mut expected = Cookie::build("foo", "bar").finish();
         assert_eq_parse!("foo=bar", expected);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -109,7 +109,7 @@ fn trim_quotes<'a>(s: &'a str) -> &'a str {
     if s.len() < 2 {
         return s;
     }
-    
+
     match (s.chars().next(), s.chars().last()) {
         (Some('"'), Some('"')) => &s[1..s.len()-1],
         _ => s


### PR DESCRIPTION
RFC 6265 section 4.1.1 defines the cookie-value as an octet that can be
surrounded by double quotes. Thus surrounding double quotes are not part
of the cookie-value and should be stripped during parsing.

ISSUE: 140