### PR TITLE
Add domain to hash function of DeltaCookie

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -61,6 +61,9 @@ impl Eq for DeltaCookie {}
 impl Hash for DeltaCookie {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name().hash(state);
+        if let Some(domain) = self.domain() {
+            domain.hash(state)
+        }
     }
 }
 


### PR DESCRIPTION
Since cookies were hashed by their names, cookies with the same name but different domains were getting overwritten. 
If the cookie has a domain, we should use it to create a hash, or is there some reason not to?

Thanks!