### PR TITLE
Update 'aes-gcm', 'hmac', 'hkdf', 'sha2'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ time = { version = "0.2.11", default-features = false, features = ["std"] }
 percent-encoding = { version = "2.0", optional = true }
 
 # dependencies for secure (private/signed) functionality
-aes-gcm = { version = "0.5.0", optional = true }
+aes-gcm = { version = "0.6.0", optional = true }
 hmac = { version = "0.7.1", optional = true }
 sha2 = { version = "0.8.2", optional = true }
 base64 = { version = "0.12.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ percent-encoding = { version = "2.0", optional = true }
 
 # dependencies for secure (private/signed) functionality
 aes-gcm = { version = "0.6.0", optional = true }
-hmac = { version = "0.7.1", optional = true }
-sha2 = { version = "0.8.2", optional = true }
+hmac = { version = "0.8.0", optional = true }
+sha2 = { version = "0.9.0", optional = true }
 base64 = { version = "0.12.1", optional = true }
 rand = { version = "0.7.3", optional = true }
-hkdf = { version = "0.8.0", optional = true }
+hkdf = { version = "0.9.0-alpha.0", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/secure/private.rs
+++ b/src/secure/private.rs
@@ -1,7 +1,7 @@
 extern crate aes_gcm;
 
 use self::aes_gcm::Aes256Gcm;
-use self::aes_gcm::aead::{Aead, NewAead, generic_array::GenericArray, Payload};
+use self::aes_gcm::aead::{Aead, AeadInPlace, NewAead, generic_array::GenericArray, Payload};
 
 use crate::secure::{base64, rand, Key};
 use crate::{Cookie, CookieJar};
@@ -48,7 +48,7 @@ impl<'a> PrivateJar<'a> {
         let (nonce, cipher) = data.split_at(NONCE_LEN);
         let payload = Payload { msg: cipher, aad: name.as_bytes() };
 
-        let aead = Aes256Gcm::new(GenericArray::clone_from_slice(&self.key));
+        let aead = Aes256Gcm::new(GenericArray::from_slice(&self.key));
         aead.decrypt(GenericArray::from_slice(nonce), payload)
             .map_err(|_| "invalid key/nonce/value: bad seal")
             .and_then(|s| String::from_utf8(s).map_err(|_| "bad unsealed utf8"))
@@ -152,7 +152,7 @@ impl<'a> PrivateJar<'a> {
         // Perform the actual sealing operation, using the cookie's name as
         // associated data to prevent value swapping.
         let aad = cookie.name().as_bytes();
-        let aead = Aes256Gcm::new(GenericArray::clone_from_slice(&self.key));
+        let aead = Aes256Gcm::new(GenericArray::from_slice(&self.key));
         let aad_tag = aead.encrypt_in_place_detached(&nonce, aad, in_out)
             .expect("encryption failure!");
 


### PR DESCRIPTION
This release uses the new `aead` v0.3 crate which makes the following changes to the API:

- `NewAead` now borrows the key, preventing needless copies
- `Aead` and `AeadInPlace` traits have been split. It appears you're using both, so this pulls them both in.

Note that these crates now depend on `generic-array` v0.14 which has an MSRV of 1.41+.