### PR TITLE
Create parse_string method that returns an iterator over cookies

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -48,4 +48,27 @@ mod test {
             _=> assert!(false),
         }
     }
+
+    #[test]
+    #[cfg(feature = "percent-encode")]
+    fn test_iter_encode() {
+        let mut ci = CookieIter::new("hello=world; foo=bar%20baz", false);
+        match ci.next() {
+            Some(Ok(cookie)) => assert_eq!(("hello", "world"), cookie.name_value()),
+            _=> assert!(false),
+        } match ci.next() {
+            Some(Ok(cookie)) => assert_eq!(("foo", "bar%20baz"), cookie.name_value()),
+            _=> assert!(false),
+        }
+
+        let mut ci = CookieIter::new("hello=world; foo=bar%20baz", true);
+        match ci.next() {
+            Some(Ok(cookie)) => assert_eq!(("hello", "world"), cookie.name_value()),
+            _=> assert!(false),
+        } match ci.next() {
+            Some(Ok(cookie)) => assert_eq!(("foo", "bar baz"), cookie.name_value()),
+            _=> assert!(false),
+        }
+    }
+
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,32 @@
+use crate::Cookie;
+use crate::parse::{
+
+pub struct CookieIter<'c> {
+    pub input: Option<&'c str>,
+}
+
+impl <'c> Iterator for CookieIter<'c> {
+    type Item = Result<Cookie<'c>, ParseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut split2 = self.input?.splitn(2, ';');
+        let unparsed = split2.next().unwrap().trim();
+        self.input = split2.next();
+        
+        Some(Cookie::parse(unparsed))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::CookieIter;
+
+    #[test]
+    fn test_iter() {
+        let ci = CookieIter { input: Some("hello=world; foo=bar") };
+        
+        for cookie in ci {
+            println!("Cookie: {:?}", cookie);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ mod jar;
 mod delta;
 mod draft;
 mod crumb;
+mod iter;
 
 #[cfg(any(feature = "private", feature = "signed"))] #[macro_use] mod secure;
 #[cfg(any(feature = "private", feature = "signed"))] pub use secure::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,10 +331,10 @@ impl<'c> Cookie<'c> {
     /// assert_eq!(("hello", "world"), cookie_iter.next().unwrap().unwrap());
     /// assert_eq!(("foo", "bar%20baz"), cookie_iter.next().unwrap().unwrap());
     /// ```
-    pub fn parse_string(s: &'c str) -> CookieIter<'c>
-    //    where S: Into<Cow<'c, str>>
+    pub fn parse_string<S>(s: S) -> CookieIter<'c>
+        where S: Into<Cow<'c, str>>
     {
-        CookieIter::new(&s, false)
+        CookieIter::new(s.into(), false)
     }
 
     /// Parses a `Cookie:` header where the name and value are percent-encoded and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,11 +350,14 @@ impl<'c> Cookie<'c> {
     /// # Example
     ///
     /// ```rust
-    /// use cookie::Cookie
+    /// use cookie::Cookie;
+    /// use cookie::ParseError;
     ///
-    /// let cookie_iter = cookie.parse_string_encoded("hello=world; foo=bar%20baz");
-    /// assert_eq!(("hello", "world"), cookie_iter.next().unwrap().unwrap());
-    /// assert_eq!(("foo", "bar baz"), cookie_iter.next().unwrap().unwrap());
+    /// let mut cookie_iter = Cookie::parse_string_encoded("hello=world; foo=bar%20baz; bin");
+    /// assert_eq!(Some(Ok(Cookie::new("hello", "world"))), cookie_iter.next());
+    /// assert_eq!(Some(Ok(Cookie::new("foo", "bar baz"))), cookie_iter.next());
+    /// assert_eq!(Some(Err(ParseError::MissingPair)), cookie_iter.next());
+    /// assert_eq!(None, cookie_iter.next());
     /// ```
     #[cfg(feature = "percent-encode")]
     #[cfg_attr(all(doc, not(doctest)), cfg(feature = "percent-encode"))]
@@ -362,24 +365,6 @@ impl<'c> Cookie<'c> {
         where S: Into<Cow<'c, str>>
     {
         CookieIter {remaining: Some(s.into()), encoded: true}
-    }
-
-    /// Wraps `self` in an `EncodedCookie`: a cost-free wrapper around `Cookie`
-    /// whose `Display` implementation percent-encodes the name and value of the
-    /// wrapped `Cookie`.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use cookie::Cookie;
-    ///
-    /// let mut c = Cookie::new("my name", "this; value?");
-    /// assert_eq!(&c.encoded().to_string(), "my%20name=this%3B%20value%3F");
-    /// ```
-    #[cfg(feature = "percent-encode")]
-    #[cfg_attr(all(doc, not(doctest)), cfg(feature = "percent-encode"))]
-    pub fn encoded<'a>(&'a self) -> EncodedCookie<'a, 'c> {
-        EncodedCookie(self)
     }
 
     /// Converts `self` into a `Cookie` with a static lifetime with as few

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,16 +325,19 @@ impl<'c> Cookie<'c> {
     /// # Example
     ///
     /// ```rust
-    /// use cookie::Cookie
+    /// use cookie::Cookie;
+    /// use cookie::ParseError;
     ///
-    /// let cookie_iter = cookie.parse_string("hello=world; foo=bar%20baz");
-    /// assert_eq!(("hello", "world"), cookie_iter.next().unwrap().unwrap());
-    /// assert_eq!(("foo", "bar%20baz"), cookie_iter.next().unwrap().unwrap());
+    /// let mut cookie_iter = Cookie::parse_string("hello=world; foo=bar%20baz; bin");
+    /// assert_eq!(Some(Ok(Cookie::new("hello", "world"))), cookie_iter.next());
+    /// assert_eq!(Some(Ok(Cookie::new("foo", "bar%20baz"))), cookie_iter.next());
+    /// assert_eq!(Some(Err(ParseError::MissingPair)), cookie_iter.next());
+    /// assert_eq!(None, cookie_iter.next());
     /// ```
     pub fn parse_string<S>(s: S) -> CookieIter<'c>
         where S: Into<Cow<'c, str>>
     {
-        CookieIter::new(s.into(), false)
+        CookieIter {remaining: Some(s.into()), encoded: false}
     }
 
     /// Parses a `Cookie:` header where the name and value are percent-encoded and
@@ -355,10 +358,10 @@ impl<'c> Cookie<'c> {
     /// ```
     #[cfg(feature = "percent-encode")]
     #[cfg_attr(all(doc, not(doctest)), cfg(feature = "percent-encode"))]
-    pub fn parse_string_encoded(s: &'c str) -> CookieIter<'c>
-    //    where S: Into<Cow<'c, str>>
+    pub fn parse_string_encoded<S>(s: S) -> CookieIter<'c>
+        where S: Into<Cow<'c, str>>
     {
-        CookieIter::new(&s, true)
+        CookieIter {remaining: Some(s.into()), encoded: true}
     }
 
     /// Wraps `self` in an `EncodedCookie`: a cost-free wrapper around `Cookie`


### PR DESCRIPTION
The motivation for this API is that I don't want to iterate over a cookie string myself if I can entrust it to a library. This function returns an iterator over cookie Results. This allows the implementer to add each cookie to their cookie jar as either deltas or original cookies. It also allows them to handle errors however they choose.