### PR TITLE
update `aes-gcm` to `v0.7.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ percent-encoding = { version = "2.0", optional = true }
 dashmap = "4.0.0-rc6"
 
 # dependencies for secure (private/signed) functionality
-aes-gcm = { version = "0.6.0", optional = true }
+aes-gcm = { version = "0.7.0", optional = true }
 hmac = { version = "0.8.0", optional = true }
 sha2 = { version = "0.9.0", optional = true }
 base64 = { version = "0.12.1", optional = true }


### PR DESCRIPTION
This removes a duplicate dependency on `opaque-debug`.

```
$ cargo tree -d --all-features
opaque-debug v0.2.3
└── aes-soft v0.4.0
    └── aes v0.4.0
        └── aes-gcm v0.6.0
            └── cookie v0.15.0-dev 

opaque-debug v0.3.0
└── sha2 v0.9.1
    └── cookie v0.15.0-dev
```