### PR TITLE
Update RustCrypto dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ time = { version = "0.2.11", default-features = false, features = ["std"] }
 percent-encoding = { version = "2.0", optional = true }
 
 # dependencies for secure (private/signed) functionality
-aes-gcm = { version = "0.7.0", optional = true }
-hmac = { version = "0.8.0", optional = true }
+aes-gcm = { version = "0.8.0", optional = true }
+hmac = { version = "0.10.0", optional = true }
 sha2 = { version = "0.9.0", optional = true }
 base64 = { version = "0.13", optional = true }
 rand = { version = "0.7.3", optional = true }
-hkdf = { version = "0.9.0", optional = true }
+hkdf = { version = "0.10.0", optional = true }
 subtle = { version = "2.3", optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
Updates the following RustCrypto dependencies to the latest versions:

- `aes-gcm` v0.8.0
- `hmac` v0.10.0
- `hkdf` v0.10.0