### PR TITLE
Update RustCrypto dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ time = { version = "0.2.11", default-features = false, features = ["std"] }
 percent-encoding = { version = "2.0", optional = true }
 
 # dependencies for secure (private/signed) functionality
-aes-gcm = { version = "0.8.0", optional = true }
-hmac = { version = "0.10.0", optional = true }
+aes-gcm = { version = "0.9.0", optional = true }
+hmac = { version = "0.11.0", optional = true }
 sha2 = { version = "0.9.0", optional = true }
 base64 = { version = "0.13", optional = true }
 rand = { version = "0.8", optional = true }
-hkdf = { version = "0.10.0", optional = true }
+hkdf = { version = "0.11.0", optional = true }
 subtle = { version = "2.3", optional = true }
 
 [build-dependencies]

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -36,7 +36,7 @@ impl<J> SignedJar<J> {
     /// Signs the cookie's value providing integrity and authenticity.
     fn sign_cookie(&self, cookie: &mut Cookie) {
         // Compute HMAC-SHA256 of the cookie's value.
-        let mut mac = Hmac::<Sha256>::new_varkey(&self.key).expect("good key");
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.key).expect("good key");
         mac.update(cookie.value().as_bytes());
 
         // Cookie's new value is [MAC | original-value].
@@ -58,7 +58,7 @@ impl<J> SignedJar<J> {
         let digest = base64::decode(digest_str).map_err(|_| "bad base64 digest")?;
 
         // Perform the verification.
-        let mut mac = Hmac::<Sha256>::new_varkey(&self.key).expect("good key");
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.key).expect("good key");
         mac.update(value.as_bytes());
         mac.verify(&digest)
             .map(|_| value.to_string())


### PR DESCRIPTION
Updates the following RustCrypto dependencies to the latest versions:

- `aes-gcm` v0.9.0
- `hmac` v0.11.0
- `hkdf` v0.11.0