### PR TITLE
Bump `aes-gcm` to v0.9.1 and enable `force-soft`; MSRV 1.41+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ time = { version = "0.2.11", default-features = false, features = ["std"] }
 percent-encoding = { version = "2.0", optional = true }
 
 # dependencies for secure (private/signed) functionality
-aes-gcm = { version = "0.9.0", optional = true }
+aes-gcm = { version = "0.9.1", optional = true, features = ["force-soft"] } # remove `force-soft` when MSRV 1.49+
 hmac = { version = "0.11.0", optional = true }
 sha2 = { version = "0.9.0", optional = true }
 base64 = { version = "0.13", optional = true }


### PR DESCRIPTION
I released a new version of `aes-gcm` with a `force-soft` feature:

https://github.com/RustCrypto/AEADs/pull/306

This disables autodetection of AES-NI, falling back on a portable constant-time software implementation.

However, in this configuration `aes-gcm` still supports an MSRV of 1.41+, as opposed to 1.49+ required by the autodetection feature.

A comment in Cargo.toml notes `force-soft` should be removed when MSRV is bumped to at least 1.49.