### PR TITLE
make draft public, in order to make use of SameSite

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ mod builder;
 mod parse;
 mod jar;
 mod delta;
-mod draft;
+pub mod draft;
 mod expiration;
 
 #[cfg(any(feature = "private", feature = "signed"))] #[macro_use] mod secure;


### PR DESCRIPTION
I am a user of actix-web, which recently did a major version release, moving to cookie 0.16.
In there SameSite, moved into the draft module.  actix-web does "pub use cookie", but in my
code "cookie::draft::SameSite" will induce an error telling that draft i s a private module.
Changing it to "pub mod cookie" fixes this problem for me, but I am uncertain that it is the correct fix.
Anyway I submit this to you as a layman's s