### PR TITLE
`chrono` feature to allow library users to either use `time` or `chrono` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = ["time"]
 
 [dependencies]
 time = { version = "0.3", default-features = false, features = ["std", "parsing", "formatting", "macros"], optional = true }
-chrono = { version = "0.4.30", optional = true }
+chrono = { version = "=0.4.24", optional = true } # Version 0.4.25 bumps MSRV
 percent-encoding = { version = "2.0", optional = true }
 
 # dependencies for secure (private/signed) functionality

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,13 @@ secure = ["private", "signed", "key-expansion"]
 private = ["aes-gcm", "base64", "rand", "subtle"]
 signed = ["hmac", "sha2", "base64", "rand", "subtle"]
 key-expansion = ["sha2", "hkdf"]
+time = ["dep:time"]
+chrono = ["dep:chrono"]
+default = ["time"]
 
 [dependencies]
-time = { version = "0.3", default-features = false, features = ["std", "parsing", "formatting", "macros"] }
+time = { version = "0.3", default-features = false, features = ["std", "parsing", "formatting", "macros"], optional = true }
+chrono = { version = "0.4.30", optional = true }
 percent-encoding = { version = "2.0", optional = true }
 
 # dependencies for secure (private/signed) functionality

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,9 +11,21 @@ cargo test --verbose --features secure
 cargo test --verbose --features 'private,key-expansion'
 cargo test --verbose --features 'signed,key-expansion'
 cargo test --verbose --features 'secure,percent-encode'
+cargo test --verbose --no-default-features --features chrono
+cargo test --verbose --no-default-features --features 'chrono,private'
+cargo test --verbose --no-default-features --features 'chrono,signed'
+cargo test --verbose --no-default-features --features 'chrono,secure'
+cargo test --verbose --no-default-features --features 'chrono,private,key-expansion'
+cargo test --verbose --no-default-features --features 'chrono,signed,key-expansion'
+cargo test --verbose --no-default-features --features 'chrono,secure,key-expansion'
+
+if cargo test --verbose --features 'time,chrono' > /dev/null 2>&1; then
+    echo 'features \"time\" and \"chrono\" cannot be enabled at the same time' >&2
+    exit 1
+fi
 
 cargo test --verbose
-cargo test --verbose --no-default-features
-cargo test --verbose --all-features
+# TODO: Compile even without `time`?
+#cargo test --verbose --no-default-features
 
 rustdoc --test README.md -L target

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,7 +25,6 @@ if cargo test --verbose --features 'time,chrono' > /dev/null 2>&1; then
 fi
 
 cargo test --verbose
-# TODO: Compile even without `time`?
-#cargo test --verbose --no-default-features
+cargo test --verbose --no-default-features
 
 rustdoc --test README.md -L target

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,6 +2,11 @@ use std::borrow::Cow;
 
 use crate::{Cookie, SameSite, Expiration};
 
+#[cfg(feature = "time")]
+use time::Duration;
+#[cfg(feature = "chrono")]
+use chrono::Duration;
+
 /// Structure that follows the builder pattern for building `Cookie` structs.
 ///
 /// To construct a cookie:
@@ -100,7 +105,7 @@ impl<'c> CookieBuilder<'c> {
     /// # }
     /// ```
     #[inline]
-    pub fn max_age(mut self, value: time::Duration) -> Self {
+    pub fn max_age(mut self, value: Duration) -> Self {
         self.cookie.set_max_age(value);
         self
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
-use crate::{Cookie, SameSite, Expiration};
+use crate::{Cookie, SameSite};
+#[cfg(any(feature = "time", feature = "chrono"))]
+use crate::Expiration;
 
 #[cfg(feature = "time")]
 use time::Duration;
@@ -84,6 +86,7 @@ impl<'c> CookieBuilder<'c> {
     /// # }
     /// ```
     #[inline]
+    #[cfg(any(feature = "time", feature = "chrono"))]
     pub fn expires<E: Into<Expiration>>(mut self, when: E) -> Self {
         self.cookie.set_expires(when);
         self
@@ -108,6 +111,7 @@ impl<'c> CookieBuilder<'c> {
     /// # }
     /// ```
     #[inline]
+    #[cfg(any(feature = "time", feature = "chrono"))]
     pub fn max_age(mut self, value: Duration) -> Self {
         self.cookie.set_max_age(value);
         self
@@ -226,6 +230,7 @@ impl<'c> CookieBuilder<'c> {
     /// # assert!(c.expires().is_some());
     /// # }
     /// ```
+    #[cfg(any(feature = "time", feature = "chrono"))]
     #[inline]
     pub fn permanent(mut self) -> Self {
         self.cookie.make_permanent();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -17,7 +17,8 @@ use chrono::Duration;
 ///
 /// # Example
 ///
-/// ```rust
+#[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+#[cfg_attr(feature = "time", doc = "```rust")]
 /// # extern crate cookie;
 /// use cookie::Cookie;
 /// use cookie::time::Duration;
@@ -62,7 +63,8 @@ impl<'c> CookieBuilder<'c> {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// # extern crate cookie;
     /// use cookie::{Cookie, Expiration};
     /// use cookie::time::OffsetDateTime;
@@ -91,7 +93,8 @@ impl<'c> CookieBuilder<'c> {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// # extern crate cookie;
     /// use cookie::Cookie;
     /// use cookie::time::Duration;
@@ -208,7 +211,8 @@ impl<'c> CookieBuilder<'c> {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// # extern crate cookie;
     /// use cookie::Cookie;
     /// use cookie::time::Duration;

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -24,6 +24,7 @@ impl DeltaCookie {
 
     /// Create a new `DeltaCookie` that is being removed from a jar. The
     /// `cookie` should be a "removal" cookie.
+    #[cfg(any(feature = "time", feature = "chrono"))]
     #[inline]
     pub fn removed(cookie: Cookie<'static>) -> DeltaCookie {
         DeltaCookie { cookie, removed: true, }

--- a/src/expiration.rs
+++ b/src/expiration.rs
@@ -1,4 +1,10 @@
-use time::OffsetDateTime;
+/// The value of `Expiration::DateTime`, type-alised from `time`.
+#[cfg(feature = "time")]
+pub type DateTime = time::OffsetDateTime;
+
+/// The value of `Expiration::DateTime`, type-alised from `chrono`.
+#[cfg(feature = "chrono")]
+pub type DateTime = chrono::DateTime<chrono::FixedOffset>;
 
 /// A cookie's expiration: either session or a date-time.
 ///
@@ -26,7 +32,7 @@ use time::OffsetDateTime;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Expiration {
     /// Expiration for a "permanent" cookie at a specific date-time.
-    DateTime(OffsetDateTime),
+    DateTime(DateTime),
     /// Expiration for a "session" cookie. Browsers define the notion of a
     /// "session" and will automatically expire session cookies when they deem
     /// the "session" to be over. This is typically, but need not be, when the
@@ -92,7 +98,7 @@ impl Expiration {
     /// let expires = Expiration::from(now);
     /// assert_eq!(expires.datetime(), Some(now));
     /// ```
-    pub fn datetime(self) -> Option<OffsetDateTime> {
+    pub fn datetime(self) -> Option<DateTime> {
         match self {
             Expiration::Session => None,
             Expiration::DateTime(v) => Some(v)
@@ -118,7 +124,7 @@ impl Expiration {
     /// assert_eq!(expires.map(|t| t + one_week).datetime(), None);
     /// ```
     pub fn map<F>(self, f: F) -> Self
-        where F: FnOnce(OffsetDateTime) -> OffsetDateTime
+        where F: FnOnce(DateTime) -> DateTime
     {
         match self {
             Expiration::Session => Expiration::Session,
@@ -127,7 +133,7 @@ impl Expiration {
     }
 }
 
-impl<T: Into<Option<OffsetDateTime>>> From<T> for Expiration {
+impl<T: Into<Option<DateTime>>> From<T> for Expiration {
     fn from(option: T) -> Self {
         match option.into() {
             Some(value) => Expiration::DateTime(value),

--- a/src/expiration.rs
+++ b/src/expiration.rs
@@ -15,7 +15,8 @@ pub type DateTime = chrono::DateTime<chrono::FixedOffset>;
 ///   * `Some(OffsetDateTime)` -> `Expiration::DateTime`
 ///   * `OffsetDateTime` -> `Expiration::DateTime`
 ///
-/// ```rust
+#[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+#[cfg_attr(feature = "time", doc = "```rust")]
 /// use cookie::Expiration;
 /// use time::OffsetDateTime;
 ///
@@ -45,7 +46,8 @@ impl Expiration {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// use cookie::Expiration;
     /// use time::OffsetDateTime;
     ///
@@ -66,7 +68,8 @@ impl Expiration {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// use cookie::Expiration;
     /// use time::OffsetDateTime;
     ///
@@ -87,7 +90,8 @@ impl Expiration {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// use cookie::Expiration;
     /// use time::OffsetDateTime;
     ///
@@ -110,7 +114,8 @@ impl Expiration {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// use cookie::Expiration;
     /// use time::{OffsetDateTime, Duration};
     ///

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -30,7 +30,8 @@ use crate::Cookie;
 /// [remove](#method.remove). Finally, cookies can be looked up via
 /// [get](#method.get):
 ///
-/// ```rust
+#[cfg_attr(any(feature = "time", feature = "chrono"), doc = "```rust")]
+#[cfg_attr(not(any(feature = "time", feature = "chrono")), doc = "```rust,ignore")]
 /// # use cookie::{Cookie, CookieJar};
 /// let mut jar = CookieJar::new();
 /// jar.add(Cookie::new("a", "one"));
@@ -57,7 +58,8 @@ use crate::Cookie;
 /// Deltas are typically used to create `Set-Cookie` headers corresponding to
 /// the changes made to a cookie jar over a period of time.
 ///
-/// ```rust
+#[cfg_attr(any(feature = "time", feature = "chrono"), doc = "```rust")]
+#[cfg_attr(not(any(feature = "time", feature = "chrono")), doc = "```rust,ignore")]
 /// # use cookie::{Cookie, CookieJar};
 /// let mut jar = CookieJar::new();
 ///
@@ -227,6 +229,7 @@ impl CookieJar {
     /// jar.remove(Cookie::named("name"));
     /// assert_eq!(jar.delta().count(), 1);
     /// ```
+    #[cfg(any(feature = "time", feature = "chrono"))]
     pub fn remove(&mut self, mut cookie: Cookie<'static>) {
         if self.original_cookies.contains(cookie.name()) {
             cookie.make_removal();
@@ -283,7 +286,8 @@ impl CookieJar {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(any(feature = "time", feature = "chrono"), doc = "```rust")]
+    #[cfg_attr(not(any(feature = "time", feature = "chrono")), doc = "```rust,ignore")]
     /// use cookie::{CookieJar, Cookie};
     ///
     /// let mut jar = CookieJar::new();
@@ -319,7 +323,8 @@ impl CookieJar {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(any(feature = "time", feature = "chrono"), doc = "```rust")]
+    #[cfg_attr(not(any(feature = "time", feature = "chrono")), doc = "```rust,ignore")]
     /// use cookie::{CookieJar, Cookie};
     ///
     /// let mut jar = CookieJar::new();
@@ -346,7 +351,8 @@ impl CookieJar {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(any(feature = "time", feature = "chrono"), doc = "```rust")]
+    #[cfg_attr(not(any(feature = "time", feature = "chrono")), doc = "```rust,ignore")]
     /// use cookie::{CookieJar, Cookie};
     ///
     /// let mut jar = CookieJar::new();
@@ -422,7 +428,8 @@ impl CookieJar {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(any(feature = "time", feature = "chrono"), doc = "```rust")]
+    #[cfg_attr(not(any(feature = "time", feature = "chrono")), doc = "```rust,ignore")]
     /// use cookie::{Cookie, CookieJar, Key};
     ///
     /// // Generate a secure key.
@@ -484,7 +491,8 @@ impl CookieJar {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(any(feature = "time", feature = "chrono"), doc = "```rust")]
+    #[cfg_attr(not(any(feature = "time", feature = "chrono")), doc = "```rust,ignore")]
     /// use cookie::{Cookie, CookieJar, Key};
     ///
     /// // Generate a secure key.
@@ -549,6 +557,7 @@ mod test {
 
     #[test]
     #[allow(deprecated)]
+    #[cfg(any(feature = "time", feature = "chrono"))]
     fn simple() {
         let mut c = CookieJar::new();
 
@@ -594,21 +603,25 @@ mod test {
         c.private_mut(&key).add(Cookie::new("encrypted", "encrypted"));
         assert_eq!(c.iter().count(), 6);
 
-        c.remove(Cookie::named("test"));
-        assert_eq!(c.iter().count(), 5);
+        #[cfg(any(feature = "time", feature = "chrono"))]
+        {
+            c.remove(Cookie::named("test"));
+            assert_eq!(c.iter().count(), 5);
 
-        c.remove(Cookie::named("signed"));
-        c.remove(Cookie::named("test2"));
-        assert_eq!(c.iter().count(), 3);
+            c.remove(Cookie::named("signed"));
+            c.remove(Cookie::named("test2"));
+            assert_eq!(c.iter().count(), 3);
 
-        c.add(Cookie::new("test2", "test2"));
-        assert_eq!(c.iter().count(), 4);
+            c.add(Cookie::new("test2", "test2"));
+            assert_eq!(c.iter().count(), 4);
 
-        c.remove(Cookie::named("test2"));
-        assert_eq!(c.iter().count(), 3);
+            c.remove(Cookie::named("test2"));
+            assert_eq!(c.iter().count(), 3);
+        }
     }
 
     #[test]
+    #[cfg(any(feature = "time", feature = "chrono"))]
     fn delta() {
         use std::collections::HashMap;
         #[cfg(feature = "time")]
@@ -653,6 +666,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(any(feature = "time", feature = "chrono"))]
     fn empty_delta() {
         let mut jar = CookieJar::new();
         jar.add(Cookie::new("name", "val"));
@@ -675,6 +689,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(any(feature = "time", feature = "chrono"))]
     fn add_remove_add() {
         let mut jar = CookieJar::new();
         jar.add_original(Cookie::new("name", "val"));
@@ -703,6 +718,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(any(feature = "time", feature = "chrono"))]
     fn replace_remove() {
         let mut jar = CookieJar::new();
         jar.add_original(Cookie::new("name", "val"));
@@ -717,6 +733,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(any(feature = "time", feature = "chrono"))]
     fn remove_with_path() {
         let mut jar = CookieJar::new();
         jar.add_original(Cookie::build("name", "val").finish());

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -609,7 +609,10 @@ mod test {
     #[test]
     fn delta() {
         use std::collections::HashMap;
+        #[cfg(feature = "time")]
         use time::Duration;
+        #[cfg(feature = "chrono")]
+        use chrono::Duration;
 
         let mut c = CookieJar::new();
 

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -184,7 +184,8 @@ impl CookieJar {
     ///
     /// Removing an _original_ cookie results in a _removal_ cookie:
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// # extern crate cookie;
     /// use cookie::{CookieJar, Cookie};
     /// use cookie::time::Duration;
@@ -244,7 +245,8 @@ impl CookieJar {
     ///
     /// Removing an _original_ cookie; no _removal_ cookie is generated:
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// # extern crate cookie;
     /// use cookie::{CookieJar, Cookie};
     /// use cookie::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,7 +576,8 @@ impl<'c> Cookie<'c> {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(not(feature = "time"), doc = "```ignore")]
+    #[cfg_attr(feature = "time", doc = "```")]
     /// use cookie::Cookie;
     ///
     /// let c = Cookie::parse("name=value").unwrap();
@@ -653,7 +654,8 @@ impl<'c> Cookie<'c> {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// use cookie::{Cookie, Expiration};
     ///
     /// let c = Cookie::parse("name=value").unwrap();
@@ -677,7 +679,8 @@ impl<'c> Cookie<'c> {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(not(feature = "time"), doc = "```ignore")]
+    #[cfg_attr(feature = "time", doc = "```")]
     /// use cookie::Cookie;
     ///
     /// let c = Cookie::parse("name=value").unwrap();
@@ -825,7 +828,8 @@ impl<'c> Cookie<'c> {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// # extern crate cookie;
     /// use cookie::Cookie;
     /// use cookie::time::Duration;
@@ -925,7 +929,8 @@ impl<'c> Cookie<'c> {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(not(feature = "time"), doc = "```ignore")]
+    #[cfg_attr(feature = "time", doc = "```")]
     /// # extern crate cookie;
     /// use cookie::{Cookie, Expiration};
     /// use cookie::time::{Duration, OffsetDateTime};
@@ -988,7 +993,8 @@ impl<'c> Cookie<'c> {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// # extern crate cookie;
     /// use cookie::Cookie;
     /// use cookie::time::Duration;
@@ -1017,7 +1023,8 @@ impl<'c> Cookie<'c> {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(not(feature = "time"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "time", doc = "```rust")]
     /// # extern crate cookie;
     /// use cookie::Cookie;
     /// use cookie::time::Duration;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -291,13 +291,14 @@ pub(crate) fn parse_date(s: &str, format: &impl Parsable) -> Result<OffsetDateTi
 #[cfg(feature = "chrono")]
 pub(crate) fn parse_date(s: &str, fmt: &str) -> Result<DateTime<FixedOffset>, chrono::ParseError> {
     use chrono::format::{Parsed, StrftimeItems, parse};
+    use crate::{ChronoDateTimeExt as _, ChronoNaiveDateTimeExt};
 
     // let res = NaiveDateTime::parse_from_str(s, fmt);
     let mut parsed = Parsed::new();
     match parse(&mut parsed, s, StrftimeItems::new(fmt)) {
         Ok(()) => {
             fn ok(parsed: Parsed) -> Result<DateTime<FixedOffset>, chrono::ParseError> {
-                Ok(parsed.to_naive_datetime_with_offset(0)?.and_utc().fixed_offset())
+                Ok(parsed.to_naive_datetime_with_offset(0)?.ext_and_utc().ext_fixed_offset())
             }
             let year = match parsed.year_mod_100 {
                 Some(year_mod_100 @ 0..=68) => 2000 + year_mod_100,

--- a/src/secure/macros.rs
+++ b/src/secure/macros.rs
@@ -11,11 +11,14 @@ macro_rules! assert_simple_behaviour {
         $secure.add(Cookie::new("another", "two"));
         assert_eq!($clear.iter().count(), 2);
 
-        $clear.remove(Cookie::named("another"));
-        assert_eq!($clear.iter().count(), 1);
+        #[cfg(any(feature = "time", feature = "chrono"))]
+        {
+            $clear.remove(Cookie::named("another"));
+            assert_eq!($clear.iter().count(), 1);
 
-        $secure.remove(Cookie::named("name"));
-        assert_eq!($clear.iter().count(), 0);
+            $secure.remove(Cookie::named("name"));
+            assert_eq!($clear.iter().count(), 0);
+        }
     })
 }
 

--- a/src/secure/private.rs
+++ b/src/secure/private.rs
@@ -219,6 +219,7 @@ impl<J: BorrowMut<CookieJar>> PrivateJar<J> {
     /// private_jar.remove(Cookie::named("name"));
     /// assert!(private_jar.get("name").is_none());
     /// ```
+    #[cfg(any(feature = "time", feature = "chrono"))]
     pub fn remove(&mut self, cookie: Cookie<'static>) {
         self.parent.borrow_mut().remove(cookie);
     }

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -196,6 +196,7 @@ impl<J: BorrowMut<CookieJar>> SignedJar<J> {
     /// signed_jar.remove(Cookie::named("name"));
     /// assert!(signed_jar.get("name").is_none());
     /// ```
+    #[cfg(any(feature = "time", feature = "chrono"))]
     pub fn remove(&mut self, cookie: Cookie<'static>) {
         self.parent.borrow_mut().remove(cookie);
     }


### PR DESCRIPTION
The `chrono` feature brings in the [`chrono` crate][chrono_cio] as a dependency & uses it to reimplement all date & time functionality. In essence, it uses [`chrono::DateTime`][chrono_datetime]`<`[`chrono::FixedOffset`][chrono_datetime]`>` in `Expiration::DateTime` rather than [`time::OffsetDateTime`][time_offsetdatetime] (`FixedOffset` seems to best match `OffsetDateTime`’s `offset` field), and [`chrono::Duration`][chrono_duration] rather than [`time::Duration`][time_duration].

The `time` feature (which becomes a default feature) represents the library’s previous behavior, implementing date & time functionality using the [`time` crate][time_cio]. Gating it behind a feature lets users opt out of using that crate, and into using the [`chrono` crate][chrono_cio] instead.

In order to let the library continue working with `default-features = false`, all date & time functionality is gated behind either of these features. So too is some other functionality that relies on date & time functionality, such as “removal“ cookies. In order to avoid adding a lot of noise to doctests those too are gated behind the `time` feature.

This is a breaking change, given that it effectively removes all date & time functionality when neither feature is enabled, e.g. when `default-features = false`. Given that the `cookies` crate did not previously have default features, it seems plausible that few were actually disabling those. When `time` is enabled (which in many cases it will be as a default feature), none of the changes are breaking.

All regular tests pass, but I have not had the opportunity to run the fuzzers yet.

[chrono_cio]: https://crates.io/crates/chrono
[chrono_datetime]: https://docs.rs/chrono/0.4.30/chrono/struct.DateTime.html
[chrono_duration]: https://docs.rs/chrono/0.4.30/chrono/struct.Duration.html
[chrono_fixedoffset]: https://docs.rs/chrono/0.4.30/chrono/offset/struct.FixedOffset.html
[time_cio]: https://crates.io/crates/time
[time_duration]: https://docs.rs/time/0.3.28/time/struct.Duration.html
[time_offsetdatetime]: https://docs.rs/time/0.3.28/time/struct.OffsetDateTime.html

---

I went ahead an implemented this as I understood that it might be welcome from a [comment](https://github.com/SergioBenitez/cookie-rs/issues/109#issuecomment-524132207) by @SergioBenitez in #109. In another [comment](https://github.com/SergioBenitez/cookie-rs/issues/109#issuecomment-827071248), @jhpratt express concern that the features wouldn’t be additive, but IIUC strictly either feature on its own _is_ additive — they’re just _mutually exclusive_, for which [the Cargo Book carves out an exception](https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features).

On a final note, also discussed in #109, removing the use of `time::Duration` (or `chrono::Duration` for that matter) in favor of `std::time::Duration` would clean this PR up a bit: the `max_age` stuff wouldn’t need to be feature-gated.
