### PR TITLE
Implement Debug for Key

### DIFF
--- a/src/secure/key.rs
+++ b/src/secure/key.rs
@@ -28,6 +28,12 @@ impl PartialEq for Key {
     }
 }
 
+impl std::fmt::Debug for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Key").finish()
+    }
+}
+
 impl Key {
     // An empty key structure, to be filled.
     const fn zero() -> Self {
@@ -297,5 +303,12 @@ mod test {
 
         assert_ne!(key_a.signing(), key_b.signing());
         assert_ne!(key_a.encryption(), key_b.encryption());
+    }
+
+    #[test]
+    fn debug_does_not_leak_key() {
+        let key = Key::generate();
+
+        assert_eq!(format!("{:?}", key), "Key");
     }
 }


### PR DESCRIPTION
I ran into a small issue with `OnceLock<Key>::set()` because it returns a `Result<(), Key>` which requires `Key` to impl `Debug` for `expect()` and `unwrap()` to be implemented. Also allows deriving `Debug` for structs which include a `Key`.