### PR TITLE
`max_age::Duration` type to replace `time` crate’s.

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -14,8 +14,7 @@ use crate::{Cookie, SameSite, Expiration, max_age};
 ///
 /// ```rust
 /// # extern crate cookie;
-/// use cookie::Cookie;
-/// use cookie::max_age::Duration;
+/// use cookie::{Cookie, max_age::Duration};
 ///
 /// # fn main() {
 /// let cookie: Cookie = Cookie::build("name", "value")
@@ -88,8 +87,7 @@ impl<'c> CookieBuilder<'c> {
     ///
     /// ```rust
     /// # extern crate cookie;
-    /// use cookie::Cookie;
-    /// use cookie::max_age::Duration;
+    /// use cookie::{Cookie, max_age::Duration};
     ///
     /// # fn main() {
     /// let c = Cookie::build("foo", "bar")
@@ -205,8 +203,7 @@ impl<'c> CookieBuilder<'c> {
     ///
     /// ```rust
     /// # extern crate cookie;
-    /// use cookie::Cookie;
-    /// use cookie::max_age::Duration;
+    /// use cookie::{Cookie, max_age::Duration};
     ///
     /// # fn main() {
     /// let c = Cookie::build("foo", "bar")

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{Cookie, SameSite, Expiration};
+use crate::{Cookie, SameSite, Expiration, max_age};
 
 /// Structure that follows the builder pattern for building `Cookie` structs.
 ///
@@ -15,7 +15,7 @@ use crate::{Cookie, SameSite, Expiration};
 /// ```rust
 /// # extern crate cookie;
 /// use cookie::Cookie;
-/// use cookie::time::Duration;
+/// use cookie::max_age::Duration;
 ///
 /// # fn main() {
 /// let cookie: Cookie = Cookie::build("name", "value")
@@ -23,7 +23,7 @@ use crate::{Cookie, SameSite, Expiration};
 ///     .path("/")
 ///     .secure(true)
 ///     .http_only(true)
-///     .max_age(Duration::days(1))
+///     .max_age(Duration::from_naive_days(1))
 ///     .finish();
 /// # }
 /// ```
@@ -89,18 +89,18 @@ impl<'c> CookieBuilder<'c> {
     /// ```rust
     /// # extern crate cookie;
     /// use cookie::Cookie;
-    /// use cookie::time::Duration;
+    /// use cookie::max_age::Duration;
     ///
     /// # fn main() {
     /// let c = Cookie::build("foo", "bar")
-    ///     .max_age(Duration::minutes(30))
+    ///     .max_age(Duration::from_mins(30))
     ///     .finish();
     ///
-    /// assert_eq!(c.max_age(), Some(Duration::seconds(30 * 60)));
+    /// assert_eq!(c.max_age(), Some(Duration::from_secs(30 * 60)));
     /// # }
     /// ```
     #[inline]
-    pub fn max_age(mut self, value: time::Duration) -> Self {
+    pub fn max_age(mut self, value: max_age::Duration) -> Self {
         self.cookie.set_max_age(value);
         self
     }
@@ -206,14 +206,14 @@ impl<'c> CookieBuilder<'c> {
     /// ```rust
     /// # extern crate cookie;
     /// use cookie::Cookie;
-    /// use cookie::time::Duration;
+    /// use cookie::max_age::Duration;
     ///
     /// # fn main() {
     /// let c = Cookie::build("foo", "bar")
     ///     .permanent()
     ///     .finish();
     ///
-    /// assert_eq!(c.max_age(), Some(Duration::days(365 * 20)));
+    /// assert_eq!(c.max_age(), Some(Duration::from_naive_days(365 * 20)));
     /// # assert!(c.expires().is_some());
     /// # }
     /// ```

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -246,7 +246,6 @@ impl CookieJar {
     /// ```rust
     /// # extern crate cookie;
     /// use cookie::{CookieJar, Cookie};
-    /// use cookie::time::Duration;
     ///
     /// # fn main() {
     /// let mut jar = CookieJar::new();

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -187,7 +187,7 @@ impl CookieJar {
     /// ```rust
     /// # extern crate cookie;
     /// use cookie::{CookieJar, Cookie};
-    /// use cookie::time::Duration;
+    /// use cookie::max_age::Duration;
     ///
     /// # fn main() {
     /// let mut jar = CookieJar::new();
@@ -202,7 +202,7 @@ impl CookieJar {
     /// let delta: Vec<_> = jar.delta().collect();
     /// assert_eq!(delta.len(), 1);
     /// assert_eq!(delta[0].name(), "name");
-    /// assert_eq!(delta[0].max_age(), Some(Duration::seconds(0)));
+    /// assert_eq!(delta[0].max_age(), Some(Duration::from_secs(0)));
     /// # }
     /// ```
     ///
@@ -609,7 +609,7 @@ mod test {
     #[test]
     fn delta() {
         use std::collections::HashMap;
-        use time::Duration;
+        use crate::max_age::Duration;
 
         let mut c = CookieJar::new();
 
@@ -633,7 +633,7 @@ mod test {
         assert!(names.get("test2").unwrap().is_none());
         assert!(names.get("test3").unwrap().is_none());
         assert!(names.get("test4").unwrap().is_none());
-        assert_eq!(names.get("original").unwrap(), &Some(Duration::seconds(0)));
+        assert_eq!(names.get("original").unwrap(), &Some(Duration::from_secs(0)));
     }
 
     #[test]

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -186,8 +186,7 @@ impl CookieJar {
     ///
     /// ```rust
     /// # extern crate cookie;
-    /// use cookie::{CookieJar, Cookie};
-    /// use cookie::max_age::Duration;
+    /// use cookie::{CookieJar, Cookie, max_age::Duration};
     ///
     /// # fn main() {
     /// let mut jar = CookieJar::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -819,8 +819,7 @@ impl<'c> Cookie<'c> {
     ///
     /// ```rust
     /// # extern crate cookie;
-    /// use cookie::Cookie;
-    /// use cookie::max_age::Duration;
+    /// use cookie::{Cookie, max_age::Duration};
     ///
     /// # fn main() {
     /// let mut c = Cookie::new("name", "value");
@@ -969,8 +968,7 @@ impl<'c> Cookie<'c> {
     ///
     /// ```rust
     /// # extern crate cookie;
-    /// use cookie::Cookie;
-    /// use cookie::max_age::Duration;
+    /// use cookie::{Cookie, max_age::Duration};
     ///
     /// # fn main() {
     /// let mut c = Cookie::new("foo", "bar");
@@ -995,8 +993,7 @@ impl<'c> Cookie<'c> {
     ///
     /// ```rust
     /// # extern crate cookie;
-    /// use cookie::Cookie;
-    /// use cookie::max_age::Duration;
+    /// use cookie::{Cookie, max_age::Duration};
     ///
     /// # fn main() {
     /// let mut c = Cookie::new("foo", "bar");
@@ -1458,9 +1455,8 @@ impl<'a, 'b> PartialEq<Cookie<'b>> for Cookie<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Cookie, SameSite, parse::parse_date};
+    use crate::{Cookie, SameSite, max_age, parse::parse_date};
     use time::OffsetDateTime;
-    use crate::max_age::Duration;
 
     #[test]
     fn format() {
@@ -1472,7 +1468,7 @@ mod tests {
         assert_eq!(&cookie.to_string(), "foo=bar; HttpOnly");
 
         let cookie = Cookie::build("foo", "bar")
-            .max_age(Duration::from_secs(10)).finish();
+            .max_age(max_age::Duration::from_secs(10)).finish();
         assert_eq!(&cookie.to_string(), "foo=bar; Max-Age=10");
 
         let cookie = Cookie::build("foo", "bar")
@@ -1529,11 +1525,11 @@ mod tests {
     #[test]
     #[ignore]
     fn format_date_wraps() {
-        let expires = OffsetDateTime::UNIX_EPOCH + Duration::MAX;
+        let expires = time::OffsetDateTime::UNIX_EPOCH + max_age::Duration::MAX;
         let cookie = Cookie::build("foo", "bar").expires(expires).finish();
         assert_eq!(&cookie.to_string(), "foo=bar; Expires=Fri, 31 Dec 9999 23:59:59 GMT");
 
-        let expires = time::macros::datetime!(9999-01-01 0:00 UTC) + Duration::from_naive_days(1000);
+        let expires = time::macros::datetime!(9999-01-01 0:00 UTC) + max_age::Duration::from_naive_days(1000);
         let cookie = Cookie::build("foo", "bar").expires(expires).finish();
         assert_eq!(&cookie.to_string(), "foo=bar; Expires=Fri, 31 Dec 9999 23:59:59 GMT");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1456,7 +1456,6 @@ impl<'a, 'b> PartialEq<Cookie<'b>> for Cookie<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{Cookie, SameSite, max_age, parse::parse_date};
-    use time::OffsetDateTime;
 
     #[test]
     fn format() {

--- a/src/max_age.rs
+++ b/src/max_age.rs
@@ -3,14 +3,9 @@
 //!
 //! [cma]: method@crate::Cookie::max_age
 
-use std::convert::TryInto;
-
-use time;
-
 /// A `Duration` type to represent a span of time for the [`Cookie::max_age`][cma] parameter. It
-/// is similar to [`std::time::Duration`], but only contains whole seconds, and provides some extra
-/// convenience methods such as [`from_mins`](Duration::from_mins()) and
-/// [`as_mins`](Duration::as_mins()) (and similar for hours & “naive” days).
+/// wraps either [`std::time::Duration`] or `[time::Duration]` (the latter if the `time` feature is
+/// enabled), but is kept within the range of `0..=u32::MAX` seconds.
 ///
 /// [`u32`] should be sufficient for cookies’ `Max-Age` parameter, since an [HTTP workgroup
 /// draft][httpwg] is proposing an upper limit of 400 days, which is currently implemented in
@@ -20,19 +15,31 @@ use time;
 /// [httpwg]: https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-max-age-attribute
 /// [chrome]: https://developer.chrome.com/blog/cookie-max-age-expires/
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Duration(u32);
+pub struct Duration(
+    time::Duration,
+);
+
+macro_rules! clamp {
+    ( $seconds:expr ) => { {
+        #[allow(unused_comparisons)]
+        if $seconds >= 0 && $seconds <= u32::MAX as _ { $seconds as u32 }
+        else if $seconds < 0 as _ { 0 }
+        else { u32::MAX }
+    } };
+}
 
 impl Duration {
 
     /// A duration of zero time.
-    pub const ZERO: Self = Self(0);
+    pub const ZERO: Self = Self(time::Duration::ZERO);
 
     /// The maximum duration, `u32::MAX` seconds.
-    pub const MAX: Self = Self(u32::MAX);
+    pub const MAX: Self = Self(time::Duration::seconds(u32::MAX as _));
 
-    /// Creates a new `Duration` from the specified number of whole seconds.
+    /// Creates a new `Duration` from the specified number of whole seconds, clamped to
+    /// `0..=u32::MAX`.
     pub const fn from_secs(seconds: u32) -> Self {
-        Self(seconds)
+        Self(time::Duration::seconds(seconds as _))
     }
 
     /// Creates a new `Duration` from the specified number of whole minutes.
@@ -53,7 +60,7 @@ impl Duration {
 
     /// Returns the number of _whole_ seconds contained by this `Duration`.
     pub const fn as_secs(&self) -> u32 {
-        self.0
+        clamp!(self.0.whole_seconds())
     }
 
     /// Returns the number of _whole_ minutes contained by this `Duration`.
@@ -71,32 +78,61 @@ impl Duration {
     pub const fn as_naive_days(&self) -> u32 {
         self.as_hours() / 24
     }
+
+    /// Returns the equivalent [`std::time::Duration`].
+    pub const fn as_std(self) -> std::time::Duration {
+        if self.0.is_negative() { std::time::Duration::ZERO } else { self.0.unsigned_abs() }
+    }
+
+    /// Returns the equivalent [`time::Duration`].
+    pub const fn as_time(self) -> time::Duration {
+        self.0
+    }
 }
 
 impl From<u32> for Duration {
     /// Creates a new `Duration` from the specified number of whole seconds.
     fn from(value: u32) -> Self {
-        Self(value)
+        Self::from_secs(value)
+    }
+}
+
+impl From<std::time::Duration> for Duration {
+    fn from(value: std::time::Duration) -> Self {
+        Self::from_secs(clamp!(value.as_secs()))
     }
 }
 
 impl From<time::Duration> for Duration {
     fn from(value: time::Duration) -> Self {
-        let seconds = value.whole_seconds();
-        Self(seconds.try_into().unwrap_or_else(|_| if seconds < 0 { 0 } else { u32::MAX }))
+        Self::from_secs(clamp!(value.whole_seconds()))
     }
 }
 
-impl std::ops::Sub<Duration> for time::OffsetDateTime {
-    type Output = time::OffsetDateTime;
+impl std::ops::Add<Duration> for Duration {
+    type Output = Duration;
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self::from_secs(clamp!((self.0 + rhs.0).whole_seconds()))
+    }
+}
+
+impl std::ops::Sub<Duration> for Duration {
+    type Output = Duration;
     fn sub(self, rhs: Duration) -> Self::Output {
-        self - time::Duration::seconds(rhs.0 as i64)
+        Self::from_secs(clamp!((self.0 - rhs.0).whole_seconds()))
     }
 }
 
 impl std::ops::Add<Duration> for time::OffsetDateTime {
     type Output = time::OffsetDateTime;
     fn add(self, rhs: Duration) -> Self::Output {
-        self + time::Duration::seconds(rhs.0 as i64)
+        self + rhs.0
+    }
+}
+
+impl std::ops::Sub<Duration> for time::OffsetDateTime {
+    type Output = time::OffsetDateTime;
+    fn sub(self, rhs: Duration) -> Self::Output {
+        self - rhs.0
     }
 }

--- a/src/max_age.rs
+++ b/src/max_age.rs
@@ -1,0 +1,102 @@
+//! This module contains the [`Duration`] type which is used for the [`Cookie::max_age`][cma]
+//! parameter.
+//!
+//! [cma]: method@crate::Cookie::max_age
+
+use std::convert::TryInto;
+
+use time;
+
+/// A `Duration` type to represent a span of time for the [`Cookie::max_age`][cma] parameter. It
+/// is similar to [`std::time::Duration`], but only contains whole seconds, and provides some extra
+/// convenience methods such as [`from_mins`](Duration::from_mins()) and
+/// [`as_mins`](Duration::as_mins()) (and similar for hours & “naive” days).
+///
+/// [`u32`] should be sufficient for cookies’ `Max-Age` parameter, since an [HTTP workgroup
+/// draft][httpwg] is proposing an upper limit of 400 days, which is currently implemented in
+/// [Chrome][chrome], and which received positive reactions from Firefox & Safari.
+///
+/// [cma]: method@crate::Cookie::max_age
+/// [httpwg]: https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-max-age-attribute
+/// [chrome]: https://developer.chrome.com/blog/cookie-max-age-expires/
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Duration(u32);
+
+impl Duration {
+
+    /// A duration of zero time.
+    pub const ZERO: Self = Self(0);
+
+    /// The maximum duration, `u32::MAX` seconds.
+    pub const MAX: Self = Self(u32::MAX);
+
+    /// Creates a new `Duration` from the specified number of whole seconds.
+    pub const fn from_secs(seconds: u32) -> Self {
+        Self(seconds)
+    }
+
+    /// Creates a new `Duration` from the specified number of whole minutes.
+    pub const fn from_mins(minutes: u32) -> Self {
+        Self::from_secs(match minutes.checked_mul(60) { Some(s) => s, _ => u32::MAX })
+    }
+
+    /// Creates a new `Duration` from the specified number of whole hours.
+    pub const fn from_hours(hours: u32) -> Self {
+        Self::from_mins(match hours.checked_mul(60) { Some(s) => s, _ => u32::MAX })
+    }
+
+    /// Creates a new `Duration` from the specified number of whole “naive” days, that is the number
+    /// of whole 24-hour periods (not considering timezone changes, etc.).
+    pub const fn from_naive_days(days: u32) -> Self {
+        Self::from_hours(match days.checked_mul(24) { Some(s) => s, _ => u32::MAX })
+    }
+
+    /// Returns the number of _whole_ seconds contained by this `Duration`.
+    pub const fn as_secs(&self) -> u32 {
+        self.0
+    }
+
+    /// Returns the number of _whole_ minutes contained by this `Duration`.
+    pub const fn as_mins(&self) -> u32 {
+        self.as_secs() / 60
+    }
+
+    /// Returns the number of _whole_ hours contained by this `Duration`.
+    pub const fn as_hours(&self) -> u32 {
+        self.as_mins() / 60
+    }
+
+    /// Returns the number of _whole_ “naive” days contained by this `Duration`, that is the number
+    /// of whole 24-hour periods.
+    pub const fn as_naive_days(&self) -> u32 {
+        self.as_hours() / 24
+    }
+}
+
+impl From<u32> for Duration {
+    /// Creates a new `Duration` from the specified number of whole seconds.
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<time::Duration> for Duration {
+    fn from(value: time::Duration) -> Self {
+        let seconds = value.whole_seconds();
+        Self(seconds.try_into().unwrap_or_else(|_| if seconds < 0 { 0 } else { u32::MAX }))
+    }
+}
+
+impl std::ops::Sub<Duration> for time::OffsetDateTime {
+    type Output = time::OffsetDateTime;
+    fn sub(self, rhs: Duration) -> Self::Output {
+        self - time::Duration::seconds(rhs.0 as i64)
+    }
+}
+
+impl std::ops::Add<Duration> for time::OffsetDateTime {
+    type Output = time::OffsetDateTime;
+    fn add(self, rhs: Duration) -> Self::Output {
+        self + time::Duration::seconds(rhs.0 as i64)
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -525,6 +525,6 @@ mod tests {
             .max_age(Duration::from_secs(max_seconds))
             .finish();
         let too_many_seconds = (max_seconds as u64) + 1;
-        assert_eq_parse!(format!(" foo=bar; Max-Age={:?}", too_many_seconds), expected);
+        assert_eq_parse!(format!(" foo=bar; Max-Age={too_many_seconds}",), expected);
     }
 }


### PR DESCRIPTION
This PR introduces a `max_age::Duration` type to use with [`Cookie::max_age`](https://docs.rs/cookie/0.17.0/cookie/struct.Cookie.html#method.max_age) (& related). It is part of an effort to resolve #109, and a building block towards making #213 truly additive.

I opted for a new type, rather than using [`std::time::Duration`](https://doc.rust-lang.org/1.72.1/std/time/struct.Duration.html), because the latter is just far larger (`u64` seconds instead of `u32`) and far more precise (nanoseconds) than what’s arguably needed for the purpose of cookies (see the new type’s docs for full motivation). @SergioBenitez, if you instead prefer `std::time::Duration` here I’m perfectly happy to make that change (I could add some conveniences like `from_mins` & `as_hours` in a `max_age::DurationExt` trait).

If we do go ahead with this `max_age::Duration` type I can add some more of the typical operator trait implementations (`Add`, `Sub`, etc.) and arithmetic methods (`checked_add`, `saturating_add`, etc.).

One downside of this change with respect to [`time::Duration`](https://docs.rs/time/0.3.28/time/struct.Duration.html#method.saturating_add) I’d like to note here is that the `set_max_age` methods that take an `impl Into<max_age::Duration>` no longer work with a plain `time::Duration` — instead of `.set_max_age(time_duration)` users would need to call e.g. `.set_max_age(Some(time_duration.into()))` (i.e. converting into `max_age::Duration` and wrapping in a `Some`).